### PR TITLE
fix: drop faraday_middleware, use faraday 2.x built-in JSON middleware

### DIFF
--- a/apple_music.gemspec
+++ b/apple_music.gemspec
@@ -25,7 +25,6 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
 
   s.add_dependency 'faraday'
-  s.add_dependency 'faraday_middleware'
   s.add_dependency 'jwt', '>= 2.2'
 
   s.add_development_dependency 'bundler'

--- a/lib/apple_music/connection.rb
+++ b/lib/apple_music/connection.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'faraday'
-require 'faraday_middleware'
 
 require 'apple_music/config'
 


### PR DESCRIPTION
## Summary

Removes the `faraday_middleware` runtime dependency and migrates to faraday 2.x's built-in JSON response middleware.

## Why

`faraday_middleware 1.2.x` declares a hard `faraday (~> 1.0)` dependency (meaning `>= 1.0, < 2.0`). This blocks upgrading faraday to 2.x, which is required to patch a high-severity CVE:

> **Faraday ≤ 2.14.2** — `NestedParamsEncoder` uncontrolled recursion allows stack-exhaustion DoS via deeply nested query parameters (CVSS 7.5). Fixed in 2.14.3.

## What changed

`faraday_middleware` was used in a single place — `connection.rb`:

```ruby
# before
require 'faraday_middleware'
conn.response :json, content_type: /\bjson\z/
```

Faraday 2.x includes `Faraday::Response::Json` as a built-in middleware, so `conn.response :json` works identically without the extra gem:

```ruby
# after — faraday_middleware dropped entirely
conn.response :json, content_type: /\bjson\z/
```

**gemspec**: `s.add_dependency 'faraday_middleware'` line removed.

## Compatibility

- `conn.response :json, content_type: /\bjson\z/` — identical behavior in faraday 2.x (built-in `Faraday::Response::Json` middleware)
- No changes to any other connection or request logic
- Compatible with faraday `>= 2.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)